### PR TITLE
Fix build-related issues

### DIFF
--- a/features/org.yamcs.studio.css.editor.feature/feature.xml
+++ b/features/org.yamcs.studio.css.editor.feature/feature.xml
@@ -231,13 +231,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.batik.ext"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.xmlgraphics"
          download-size="0"
          install-size="0"

--- a/releng/org.yamcs.studio.platform/org.yamcs.studio.platform.target
+++ b/releng/org.yamcs.studio.platform/org.yamcs.studio.platform.target
@@ -39,50 +39,49 @@
             <repository location="http://download.eclipse.org/nebula/releases/1.4.0"/>
         </location>
         <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-            <unit id="org.apache.batik.anim" version="1.9.1.v20180417-1407"/>
-            <unit id="org.apache.batik.anim.source" version="1.9.1.v20180417-1407"/>
-            <unit id="org.apache.batik.bridge" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.bridge.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.constants" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.constants.source" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.css" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.css.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.dom" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.dom.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.dom.svg" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.dom.svg.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.ext" version="1.9.1.v20180227-1645"/>
+            <unit id="org.apache.batik.anim" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.anim.source" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.bridge" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.bridge.source" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.constants" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.constants.source" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.css" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.css.source" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.dom" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.dom.source" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.dom.svg" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.dom.svg.source" version="1.9.1.v20181015-1528"/>
             <unit id="org.apache.batik.ext.awt" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.ext.awt.source" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.ext.source" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.extension" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.extension.source" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.gvt" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.gvt.source" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.i18n" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.i18n.source" version="1.9.1.v20180227-1645"/>
+            <unit id="org.apache.batik.i18n" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.i18n.source" version="1.10.0.v20180703-1553"/>
             <unit id="org.apache.batik.parser" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.parser.source" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.script" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.script.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.transcoder" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.transcoder.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.util" version="1.9.1.v20180227-1645"/>
+            <unit id="org.apache.batik.transcoder" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.transcoder.source" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.util" version="1.10.0.v20180703-1553"/>
+            <unit id="org.apache.batik.util.source" version="1.10.0.v20180703-1553"/>
             <unit id="org.apache.batik.util.gui" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.util.gui.source" version="1.9.1.v20180227-1645"/>
-            <unit id="org.apache.batik.util.source" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.xml" version="1.9.1.v20180227-1645"/>
             <unit id="org.apache.batik.xml.source" version="1.9.1.v20180227-1645"/>
-            <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/S20180504181223/repository"/>
+            <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository"/>
             <unit id="org.apache.batik.codec" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.codec.source" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.svggen" version="1.9.1.v20180313-1559"/>
             <unit id="org.apache.batik.svggen.source" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.swing" version="1.9.1.v20180313-1559"/>
-            <unit id="org.apache.batik.swing.source" version="1.9.1.v20180313-1559"/>
+            <unit id="org.apache.batik.swing" version="1.9.1.v20181015-1528"/>
+            <unit id="org.apache.batik.swing.source" version="1.9.1.v20181015-1528"/>
             <unit id="org.apache.xalan" version="2.7.1.v201005080400"/>
             <unit id="org.apache.xml.serializer" version="2.7.1.v201005080400"/>
-            <unit id="org.apache.xmlgraphics" version="2.2.0.v20180410-1551"/>
+            <unit id="org.apache.xmlgraphics" version="2.2.0.v20180809-1640"/>
+            <unit id="org.apache.xmlgraphics.source" version="2.2.0.v20180809-1640"/>
         </location>
         <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.emf.common.feature.group" version="2.13.0.v20170609-0707"/>


### PR DESCRIPTION
The old orbit repository URL does not longer exist so I replaced it with
an official one from the "Recommended: Long term, persisted repositories." list
on https://download.eclipse.org/tools/orbit/downloads/

Note that org.apache.batik.ext was nowhere to be found, but it also
does not seem to be used or required so I just removed it altogether.