### PR TITLE
Events source filter

### DIFF
--- a/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLog.java
+++ b/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLog.java
@@ -72,7 +72,7 @@ public class EventLog extends Composite implements YamcsAware {
 
         Composite filterBar = new Composite(this, SWT.NONE);
         filterBar.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        gl = new GridLayout(4, false);
+        gl = new GridLayout(6, false);
         gl.marginHeight = 0;
         gl.verticalSpacing = 0;
         filterBar.setLayout(gl);
@@ -91,6 +91,10 @@ public class EventLog extends Composite implements YamcsAware {
         Combo severityCombo = new Combo(filterBar, SWT.DROP_DOWN | SWT.READ_ONLY);
         severityCombo.setItems("INFO", "WATCH", "WARNING", "DISTRESS", "CRITICAL", "SEVERE");
         severityCombo.select(0);
+        
+        Label sourceLabel = new Label(filterBar, SWT.NONE);
+        sourceLabel.setText("Source:");
+        Combo sourceCombo = new Combo(filterBar, SWT.DROP_DOWN | SWT.READ_ONLY);
 
         Composite tableViewerWrapper = new Composite(this, SWT.NONE);
         tableViewerWrapper.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -170,6 +174,12 @@ public class EventLog extends Composite implements YamcsAware {
         severityCombo.addListener(SWT.Selection, evt -> {
             EventSeverity severity = EventSeverity.valueOf(severityCombo.getText());
             severityFilter.setMinimumSeverity(severity);
+            tableViewer.refresh();
+        });
+        
+        EventLogSourceFilter sourceFilter = new EventLogSourceFilter(sourceCombo);
+        tableViewer.addFilter(sourceFilter);
+        sourceCombo.addListener(SWT.Selection, evt -> {
             tableViewer.refresh();
         });
 

--- a/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLogSourceFilter.java
+++ b/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLogSourceFilter.java
@@ -10,7 +10,7 @@ import org.yamcs.protobuf.Yamcs.Event;
 
 /**
  * Allows the user to select the source for the events managed by EventLogTableViewer from a dropdown Combo box.
- * Scoped to the package as this should only be used in the org.yamcs.studio.eventlog package. 
+ * Scoped to the package as this should only be used in the org.yamcs.studio.eventlog package.
  * @author lgomez
  *
  */
@@ -20,11 +20,11 @@ class EventLogSourceFilter extends ViewerFilter {
     private final String ANY_SOURCE = "Any ";
 
     /**
-     * 
+     *
      * @param sourceCombo The combo box which will be populated with the items(such as event sources)
      * in the select filter.
      * @apiNote The sourceCombo's items are set to the string ANY_SOURCE. Meaning that items previously set
-     * in this combo box will be overwritten. 
+     * in this combo box will be overwritten.
      */
     public EventLogSourceFilter(Combo sourceCombo) {
         this.sourceCombo = sourceCombo;

--- a/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLogSourceFilter.java
+++ b/org.yamcs.studio.eventlog/src/main/java/org/yamcs/studio/eventlog/EventLogSourceFilter.java
@@ -1,0 +1,59 @@
+package org.yamcs.studio.eventlog;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.swt.widgets.Combo;
+import org.yamcs.protobuf.Yamcs.Event;
+
+/**
+ * Allows the user to select the source for the events managed by EventLogTableViewer from a dropdown Combo box.
+ * Scoped to the package as this should only be used in the org.yamcs.studio.eventlog package. 
+ * @author lgomez
+ *
+ */
+class EventLogSourceFilter extends ViewerFilter {
+    private LinkedHashSet<String> eventSources = new LinkedHashSet<String>(); // Not sure if this is needed anymore
+    private Combo sourceCombo;
+    private final String ANY_SOURCE = "Any ";
+
+    /**
+     * 
+     * @param sourceCombo The combo box which will be populated with the items(such as event sources)
+     * in the select filter.
+     * @apiNote The sourceCombo's items are set to the string ANY_SOURCE. Meaning that items previously set
+     * in this combo box will be overwritten. 
+     */
+    public EventLogSourceFilter(Combo sourceCombo) {
+        this.sourceCombo = sourceCombo;
+        sourceCombo.setItems(ANY_SOURCE);
+        sourceCombo.select(0);
+    }
+
+    public String[] getEventSources() {
+        return Arrays.copyOf(eventSources.toArray(), eventSources.size(), String[].class);
+    }
+
+    @Override
+    public boolean select(Viewer viewer, Object parentElement, Object element) {
+        if (element instanceof EventLogItem) {
+            Event event = ((EventLogItem) element).event;
+            if (!eventSources.contains(event.getSource())) {
+                eventSources.add(event.getSource());
+                sourceCombo.add(event.getSource());
+            }
+            if (event.getSource().equals(sourceCombo.getText())) {
+                return true;
+            } else {
+                if (sourceCombo.getText().equals(ANY_SOURCE)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hello everyone,

Hope you are all doing well.

We've always enjoyed the source event filter that exists on yamcs WebApp, and it was was always unfortunate that the feature was not in Studio as well.

I have added an events source filter to the EventsLog toolbar. I tried my best to follow the same patterns in `EventLogSeverityFilter`. The only wrinkle in this filter is that since I wanted the dropdown box to have sources up to date just like the WebApp does, I took the liberty of tweaking the pattern accordingly. Hopefully there aren't red flags in he way I implemented it.

Cheers
Lorenzo