### PR TITLE
Command History: workaround a weird hang

### DIFF
--- a/bundles/org.csstudio.autocomplete.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.autocomplete.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PV Autocomplete UI
 Bundle-SymbolicName: org.csstudio.autocomplete.ui;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.autocomplete.ui.AutoCompleteUIPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.csstudio.autocomplete,

--- a/bundles/org.csstudio.autocomplete.ui/pom.xml
+++ b/bundles/org.csstudio.autocomplete.ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.autocomplete.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.autocomplete/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.autocomplete/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PV Autocomplete
 Bundle-SymbolicName: org.csstudio.autocomplete;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.autocomplete.AutoCompletePlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,

--- a/bundles/org.csstudio.autocomplete/pom.xml
+++ b/bundles/org.csstudio.autocomplete/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.autocomplete</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.examples/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CS-Studio Examples
 Bundle-SymbolicName: org.csstudio.examples;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.examples.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/bundles/org.csstudio.examples/pom.xml
+++ b/bundles/org.csstudio.examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.examples</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.opibuilder.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BOY Editor Plugin
 Bundle-SymbolicName: org.csstudio.opibuilder.editor;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.filesystem,
  org.eclipse.ui.editors,

--- a/bundles/org.csstudio.opibuilder.editor/pom.xml
+++ b/bundles/org.csstudio.opibuilder.editor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder.editor</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.opibuilder.widgets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY Widgets Plug-in
 Bundle-Description: Widgets for BOY
 Bundle-SymbolicName: org.csstudio.opibuilder.widgets;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.opibuilder.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.core.resources,

--- a/bundles/org.csstudio.opibuilder.widgets/pom.xml
+++ b/bundles/org.csstudio.opibuilder.widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.csstudio.opibuilder.widgets</artifactId>

--- a/bundles/org.csstudio.opibuilder/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.opibuilder/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BOY base plugin
 Bundle-Description: Base plugin of BOY
 Bundle-SymbolicName: org.csstudio.opibuilder;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.opibuilder.OPIBuilderPlugin
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Bundle-Localization: plugin

--- a/bundles/org.csstudio.opibuilder/pom.xml
+++ b/bundles/org.csstudio.opibuilder/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.opibuilder</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.simplepv/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.simplepv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: A simple pv connection layer.
 Bundle-SymbolicName: org.csstudio.simplepv;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Xihui Chen <chenx1@ornl.gov>, Kay Kasemir <kasemirk@ornl.gov>
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.diirt,

--- a/bundles/org.csstudio.simplepv/pom.xml
+++ b/bundles/org.csstudio.simplepv/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.simplepv</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.swt.widgets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SWT Widgets
 Bundle-Description: Widgets figure for draw2d and SWT applications.
 Bundle-SymbolicName: org.csstudio.swt.widgets
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Activator: org.csstudio.swt.widgets.Activator
 Bundle-Vendor: Xihui Chen<chenx1@ornl.gov> - SNS
 Require-Bundle: org.eclipse.ui,

--- a/bundles/org.csstudio.swt.widgets/pom.xml
+++ b/bundles/org.csstudio.swt.widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.csstudio.swt.widgets</artifactId>

--- a/bundles/org.csstudio.ui.util/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.ui.util/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SWT/JFace utilities
 Bundle-Description: Helper classes for Drag-and-Drop support, adapting selections, ...
 Bundle-SymbolicName: org.csstudio.ui.util
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Gabriele Carcassi <carcassi@bnl.gov>, Kay Kasemir <kasemirk@ornl.gov> - BNL, SNS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.csstudio.autocomplete.ui,

--- a/bundles/org.csstudio.ui.util/pom.xml
+++ b/bundles/org.csstudio.ui.util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.ui.util</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.utility.batik/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.utility.batik/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CS-Studio Batik Util
 Bundle-SymbolicName: org.csstudio.utility.batik;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: CS-Studio <cs-studio-core@lists.sourceforge.net>
 Bundle-Activator: org.csstudio.utility.batik.Activator
 Require-Bundle: org.apache.batik.bridge,

--- a/bundles/org.csstudio.utility.batik/pom.xml
+++ b/bundles/org.csstudio.utility.batik/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.utility.batik</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.csstudio.workspace/META-INF/MANIFEST.MF
+++ b/bundles/org.csstudio.workspace/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: (TO REVIEW) Workspace Plug-in
 Bundle-SymbolicName: org.csstudio.workspace;singleton:=true
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.core.runtime
 Bundle-Activator: org.csstudio.platform.workspace.Activator
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.csstudio.workspace/pom.xml
+++ b/bundles/org.csstudio.workspace/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   <artifactId>org.csstudio.workspace</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.diirt/META-INF/MANIFEST.MF
+++ b/bundles/org.diirt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: DIIRT
 Bundle-SymbolicName: org.diirt
 Bundle-Vendor: Space Applications Services
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.antlr.runtime;bundle-version="[3.2,4)"
 Import-Package: org.osgi.framework

--- a/bundles/org.diirt/pom.xml
+++ b/bundles/org.diirt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.diirt</artifactId>

--- a/bundles/org.yamcs.studio.alarms/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.alarms/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Alarms
 Bundle-SymbolicName: org.yamcs.studio.alarms;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.yamcs.studio.core,
  org.yamcs.studio.core.ui,
  org.yamcs.client,

--- a/bundles/org.yamcs.studio.alarms/pom.xml
+++ b/bundles/org.yamcs.studio.alarms/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.alarms</artifactId>

--- a/bundles/org.yamcs.studio.archive/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.archive/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Archive
 Bundle-SymbolicName: org.yamcs.studio.archive;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.yamcs.studio.core,
  org.yamcs.studio.core.ui,

--- a/bundles/org.yamcs.studio.archive/pom.xml
+++ b/bundles/org.yamcs.studio.archive/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.archive</artifactId>

--- a/bundles/org.yamcs.studio.commanding/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.commanding/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Commanding
 Bundle-SymbolicName: org.yamcs.studio.commanding;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.yamcs.studio.core,
  org.yamcs.studio.core.ui,

--- a/bundles/org.yamcs.studio.commanding/pom.xml
+++ b/bundles/org.yamcs.studio.commanding/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.commanding</artifactId>

--- a/bundles/org.yamcs.studio.commanding/src/main/java/org/yamcs/studio/commanding/cmdhist/CommandHistoryView.java
+++ b/bundles/org.yamcs.studio.commanding/src/main/java/org/yamcs/studio/commanding/cmdhist/CommandHistoryView.java
@@ -519,7 +519,8 @@ public class CommandHistoryView extends ViewPart {
                 }
             } else {
                 column.setData("hidden", true);
-                column.setWidth(0);
+                // column.setWidth(0); // hide this column
+                column.setWidth(1); // workaround a weird hang when "Command History" is set to "Show key columns only" on specific Linux configs
             }
         }
 

--- a/bundles/org.yamcs.studio.core.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.core.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Yamcs Studio Core UI
 Bundle-SymbolicName: org.yamcs.studio.core.ui;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.console,
  org.eclipse.core.runtime,

--- a/bundles/org.yamcs.studio.core.ui/pom.xml
+++ b/bundles/org.yamcs.studio.core.ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.core.ui</artifactId>

--- a/bundles/org.yamcs.studio.core/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Yamcs Studio Core
 Bundle-SymbolicName: org.yamcs.studio.core;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.yamcs.client
 Export-Package: org.yamcs.studio.core,

--- a/bundles/org.yamcs.studio.core/pom.xml
+++ b/bundles/org.yamcs.studio.core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.core</artifactId>

--- a/bundles/org.yamcs.studio.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.css.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Yamcs Studio: CS-Studio Interfacing
 Bundle-SymbolicName: org.yamcs.studio.css.core;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.core.resources,

--- a/bundles/org.yamcs.studio.css.core/pom.xml
+++ b/bundles/org.yamcs.studio.css.core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.css.core</artifactId>

--- a/bundles/org.yamcs.studio.css.script/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.css.script/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Yamcs Script Extensions for OPIBuilder
 Bundle-SymbolicName: org.yamcs.studio.css.script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Space Applications Services
 Fragment-Host: org.csstudio.opibuilder
 Require-Bundle: org.yamcs.studio.core,

--- a/bundles/org.yamcs.studio.css.script/pom.xml
+++ b/bundles/org.yamcs.studio.css.script/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.css.script</artifactId>

--- a/bundles/org.yamcs.studio.css.theming/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.css.theming/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Theming
 Bundle-SymbolicName: org.yamcs.studio.css.theming;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/bundles/org.yamcs.studio.css.theming/pom.xml
+++ b/bundles/org.yamcs.studio.css.theming/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.css.theming</artifactId>

--- a/bundles/org.yamcs.studio.displays/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.displays/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Displays
 Bundle-SymbolicName: org.yamcs.studio.displays;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.yamcs.studio.core,
  org.yamcs.studio.core.ui,

--- a/bundles/org.yamcs.studio.displays/pom.xml
+++ b/bundles/org.yamcs.studio.displays/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.displays</artifactId>

--- a/bundles/org.yamcs.studio.editor.base/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.editor.base/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Yamcs Studio Editor Base
 Bundle-SymbolicName: org.yamcs.studio.editor.base;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/bundles/org.yamcs.studio.editor.base/pom.xml
+++ b/bundles/org.yamcs.studio.editor.base/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.editor.base</artifactId>

--- a/bundles/org.yamcs.studio.eventlog/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.eventlog/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Yamcs Studio Event Log
 Bundle-SymbolicName: org.yamcs.studio.eventlog;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.yamcs.studio.core,
  org.yamcs.studio.core.ui,
  org.yamcs.client,

--- a/bundles/org.yamcs.studio.eventlog/pom.xml
+++ b/bundles/org.yamcs.studio.eventlog/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.eventlog</artifactId>

--- a/bundles/org.yamcs.studio.explorer/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.explorer/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Exlorer
 Bundle-SymbolicName: org.yamcs.studio.explorer;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/bundles/org.yamcs.studio.explorer/pom.xml
+++ b/bundles/org.yamcs.studio.explorer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.explorer</artifactId>

--- a/bundles/org.yamcs.studio.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.yamcs.studio.monitoring/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Monitoring
 Bundle-SymbolicName: org.yamcs.studio.monitoring;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.yamcs.studio.core,
  org.yamcs.studio.core.ui,

--- a/bundles/org.yamcs.studio.monitoring/pom.xml
+++ b/bundles/org.yamcs.studio.monitoring/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.bundles</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.monitoring</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>yamcs-studio</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.bundles</artifactId>

--- a/features/org.yamcs.studio.core.feature/feature.xml
+++ b/features/org.yamcs.studio.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.yamcs.studio.core.feature"
       label="Yamcs Studio Components"
-      version="1.0.10.qualifier"
+      version="1.0.11.qualifier"
       provider-name="Space Applications Services"
       plugin="org.yamcs.studio.core.ui">
 

--- a/features/org.yamcs.studio.core.feature/pom.xml
+++ b/features/org.yamcs.studio.core.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.features</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.core.feature</artifactId>

--- a/features/org.yamcs.studio.css.editor.feature/feature.xml
+++ b/features/org.yamcs.studio.css.editor.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.yamcs.studio.css.editor.feature"
       label="Yamcs CS-Studio Editor Components"
-      version="1.0.10.qualifier"
+      version="1.0.11.qualifier"
       provider-name="Space Applications Services">
 
    <plugin

--- a/features/org.yamcs.studio.css.editor.feature/pom.xml
+++ b/features/org.yamcs.studio.css.editor.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.features</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.css.editor.feature</artifactId>

--- a/features/org.yamcs.studio.eclipse.feature/feature.xml
+++ b/features/org.yamcs.studio.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.yamcs.studio.eclipse.feature"
       label="Yamcs Eclipse Components"
-      version="1.0.10.qualifier"
+      version="1.0.11.qualifier"
       provider-name="Space Applications Services">
 
    <includes

--- a/features/org.yamcs.studio.eclipse.feature/pom.xml
+++ b/features/org.yamcs.studio.eclipse.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.features</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.eclipse.feature</artifactId>

--- a/features/org.yamcs.studio.editor.feature/feature.xml
+++ b/features/org.yamcs.studio.editor.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.yamcs.studio.editor.feature"
       label="Yamcs Studio Editor"
-      version="1.0.10.qualifier"
+      version="1.0.11.qualifier"
       provider-name="Space Applications Services">
 
    <plugin

--- a/features/org.yamcs.studio.editor.feature/pom.xml
+++ b/features/org.yamcs.studio.editor.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.features</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.editor.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>yamcs-studio</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.yamcs.studio.features</artifactId>

--- a/p2deps/org.yamcs.client/pom.xml
+++ b/p2deps/org.yamcs.client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.p2deps</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.client</artifactId>

--- a/p2deps/org.yamcs.studio.p2deps.repository/pom.xml
+++ b/p2deps/org.yamcs.studio.p2deps.repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.p2deps</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.p2deps.repository</artifactId>

--- a/p2deps/pom.xml
+++ b/p2deps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>yamcs-studio</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.p2deps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.yamcs.studio</groupId>
   <artifactId>yamcs-studio</artifactId>
-  <version>1.0.10-SNAPSHOT</version>
+  <version>1.0.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <organization>

--- a/releng/org.yamcs.studio.editor.product/pom.xml
+++ b/releng/org.yamcs.studio.editor.product/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.releng</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.editor.product</artifactId>

--- a/releng/org.yamcs.studio.editor.product/yamcs-studio.product
+++ b/releng/org.yamcs.studio.editor.product/yamcs-studio.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Yamcs Studio" uid="yamcs-studio" id="org.yamcs.studio.editor.product" application="org.yamcs.studio.editor.application" version="1.0.10.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Yamcs Studio" uid="yamcs-studio" id="org.yamcs.studio.editor.product" application="org.yamcs.studio.editor.application" version="1.0.11.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.yamcs.studio.editor/icons/aboutSide.png"/>
@@ -67,10 +67,10 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
    </plugins>
 
    <features>
-      <feature id="org.yamcs.studio.core.feature" version="1.0.10.qualifier"/>
-      <feature id="org.yamcs.studio.css.editor.feature" version="1.0.10.qualifier"/>
-      <feature id="org.yamcs.studio.eclipse.feature" version="1.0.10.qualifier"/>
-      <feature id="org.yamcs.studio.editor.feature" version="1.0.10.qualifier"/>
+      <feature id="org.yamcs.studio.core.feature" version="1.0.11.qualifier"/>
+      <feature id="org.yamcs.studio.css.editor.feature" version="1.0.11.qualifier"/>
+      <feature id="org.yamcs.studio.eclipse.feature" version="1.0.11.qualifier"/>
+      <feature id="org.yamcs.studio.editor.feature" version="1.0.11.qualifier"/>
    </features>
 
    <configurations>

--- a/releng/org.yamcs.studio.editor/META-INF/MANIFEST.MF
+++ b/releng/org.yamcs.studio.editor/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Yamcs Studio Editor
 Bundle-SymbolicName: org.yamcs.studio.editor;singleton:=true
 Bundle-Vendor: Space Applications Services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.yamcs.studio.editor.base

--- a/releng/org.yamcs.studio.editor/pom.xml
+++ b/releng/org.yamcs.studio.editor/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.releng</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.editor</artifactId>

--- a/releng/org.yamcs.studio.platform/org.yamcs.studio.platform.target
+++ b/releng/org.yamcs.studio.platform/org.yamcs.studio.platform.target
@@ -94,7 +94,7 @@
         </location>
         <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
             <unit id="org.python.jython" version="2.7.0.release"/>
-            <repository location="https://nexus.spaceapplications.com/repository/yamcs/p2/yamcs-studio-build-deps"/>
+            <repository location="https://dl.yamcs.org/p2/yamcs-studio-build-deps"/>
         </location>
     </locations>
 </target>

--- a/releng/org.yamcs.studio.platform/pom.xml
+++ b/releng/org.yamcs.studio.platform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.releng</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.platform</artifactId>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>yamcs-studio</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.releng</artifactId>

--- a/tests/org.yamcs.studio.commanding.tests/META-INF/MANIFEST.MF
+++ b/tests/org.yamcs.studio.commanding.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Yamcs Studio Commanding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.yamcs.studio.commanding.tests
 Bundle-Vendor: Space Applications Services
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Fragment-Host: org.yamcs.studio.commanding
 Require-Bundle: org.junit
 Automatic-Module-Name: org.yamcs.studio.commanding.tests

--- a/tests/org.yamcs.studio.commanding.tests/pom.xml
+++ b/tests/org.yamcs.studio.commanding.tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.tests</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.commanding.tests</artifactId>

--- a/tests/org.yamcs.studio.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.yamcs.studio.core.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Yamcs Studio Core Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.yamcs.studio.core.tests
 Bundle-Vendor: Space Applications Services
-Bundle-Version: 1.0.10.qualifier
+Bundle-Version: 1.0.11.qualifier
 Fragment-Host: org.yamcs.studio.core
 Require-Bundle: org.junit
 Automatic-Module-Name: org.yamcs.studio.core.tests

--- a/tests/org.yamcs.studio.core.tests/pom.xml
+++ b/tests/org.yamcs.studio.core.tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>org.yamcs.studio.tests</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.yamcs.studio.core.tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.yamcs.studio</groupId>
     <artifactId>yamcs-studio</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.yamcs.studio.tests</artifactId>


### PR DESCRIPTION
When "Command History" is set to "Show key columns only" it seems to hang when there are more than 8-10 lines in the Command History.

Reproducible on Ubuntu 20.04+Xorg+openbox+LXQt and Debian 10+Xorg+xfwm4+LXQt with openjdk-8-jdk and with Sun Java 8 with CDMCS.

The proper fix would be to rebuild the Command History layout with or without those columns, instead of just hiding them.